### PR TITLE
#3 テンプレートのもつフィールドの表示

### DIFF
--- a/src/__tests__/components/model/resume/Edit.spec.tsx
+++ b/src/__tests__/components/model/resume/Edit.spec.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import Edit from '@/components/model/resume/Edit';
+import { render } from '@testing-library/react';
+import { RecoilRoot } from 'recoil';
+
+jest.mock('next/router', () => ({
+  useRouter: () => {
+    return {
+      query: {
+        id: 'resume',
+      },
+    };
+  },
+}));
+
+describe('components/model/resume/Edit', () => {
+  test('テンプレートの持つフィールドが全て表示される', () => {
+    const { getAllByTestId } = render(
+      <RecoilRoot>
+        <Edit />
+      </RecoilRoot>,
+    );
+
+    const fields = getAllByTestId('field');
+
+    expect(fields.length).toBe(15);
+  });
+});

--- a/src/__tests__/components/model/resume/Title.spec.tsx
+++ b/src/__tests__/components/model/resume/Title.spec.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import Title from '@/components/model/resume/Title';
+import { render, fireEvent } from '@testing-library/react';
+
+describe('components/model/resume/Title', () => {
+  test('props の title が描画される', () => {
+    const onChange = jest.fn();
+    const { container } = render(<Title title="test-title" onChange={onChange} />);
+    const title = container.querySelector('h1');
+
+    expect(title?.textContent).toBe('test-title');
+  });
+
+  test('編集ボタンをクリックすると入力フォームに変化する', () => {
+    const onChange = jest.fn();
+    const { container, getByText } = render(<Title title="test-title" onChange={onChange} />);
+    const editButton = getByText('編集');
+
+    fireEvent.click(editButton);
+    const title = container.querySelector('h1');
+    const input = container.querySelector('input');
+    const cancelButton = getByText('キャンセル');
+    const saveButton = getByText('保存');
+
+    expect(title).toBeNull();
+    expect(input?.value).toBe('test-title');
+    expect(saveButton).toBeInTheDocument();
+    expect(cancelButton).toBeInTheDocument();
+  });
+
+  test('保存ボタンがクリックされた時 onChange が呼ばれ、通常の表示に戻る', () => {
+    const onChange = jest.fn();
+    const { container, getByText } = render(<Title title="test-title" onChange={onChange} />);
+    const editButton = getByText('編集');
+
+    fireEvent.click(editButton);
+    const saveButton = getByText('保存');
+    const input = container.querySelector('input');
+    fireEvent.change(input!, { target: { value: 'test-title-changed' } });
+    fireEvent.click(saveButton);
+
+    expect(onChange).toBeCalledWith('test-title-changed');
+    const title = container.querySelector('h1');
+    expect(title?.textContent).toBe('test-title-changed');
+  });
+
+  test('input 内で Enter キーが押された時 onChange が呼ばれ、通常の表示の戻る', () => {
+    const onChange = jest.fn();
+    const { container, getByText } = render(<Title title="test-title" onChange={onChange} />);
+    const editButton = getByText('編集');
+
+    fireEvent.click(editButton);
+    const input = container.querySelector('input');
+    fireEvent.change(input!, { target: { value: 'test-title-changed' } });
+    fireEvent.keyDown(input!, { key: 'Enter' });
+
+    expect(onChange).toBeCalledWith('test-title-changed');
+    const title = container.querySelector('h1');
+    expect(title?.textContent).toBe('test-title-changed');
+  });
+
+  test('キャンセルボタンがクリックされた時 onChange は呼ばれつ、通常の表示に戻る', () => {
+    const onChange = jest.fn();
+    const { container, getByText } = render(<Title title="test-title" onChange={onChange} />);
+    const editButton = getByText('編集');
+
+    fireEvent.click(editButton);
+    const cancelButton = getByText('キャンセル');
+    const input = container.querySelector('input');
+    fireEvent.change(input!, { target: { value: 'test-title-changed' } });
+    fireEvent.click(cancelButton);
+
+    expect(onChange).not.toBeCalled();
+    const title = container.querySelector('h1');
+    expect(title?.textContent).toBe('test-title');
+  });
+});

--- a/src/__tests__/components/model/resume/form/NumberField.spec.tsx
+++ b/src/__tests__/components/model/resume/form/NumberField.spec.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
+import '@testing-library/jest-dom';
 import { fireEvent, render } from '@testing-library/react';
 import { FieldProps } from '../../../../../components/model/resume/form/Form';
 import NumberField from '../../../../../components/model/resume/form/NumberField';
+import { NumberFieldOptions } from '@/store/templateState/types';
 
 describe('NumberField component', () => {
-  let props: FieldProps<number>;
+  let props: FieldProps<number, NumberFieldOptions>;
 
   beforeEach(() => {
     props = {
@@ -26,6 +28,11 @@ describe('NumberField component', () => {
     const input = getByTestId('input') as HTMLInputElement;
 
     expect(input.value).toBe('25');
+  });
+
+  test('optionsでunitを渡した場合設定される', () => {
+    const { getByText } = render(<NumberField {...props} options={{ unit: '人' }} />);
+    expect(getByText('人')).toBeInTheDocument();
   });
 
   test('フォームに入力した時onChangeが呼ばれる', () => {

--- a/src/__tests__/components/model/resume/form/ShortTextField.spec.tsx
+++ b/src/__tests__/components/model/resume/form/ShortTextField.spec.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import { FieldProps } from '../../../../../components/model/resume/form/Form';
 import ShortTextField from '../../../../../components/model/resume/form/ShortTextField';
+import { ShortTextFieldOptions } from '@/store/templateState/types';
 
 describe('ShortTextField component', () => {
-  let props: FieldProps<string>;
+  let props: FieldProps<string, ShortTextFieldOptions>;
 
   beforeEach(() => {
     props = {
@@ -26,6 +27,20 @@ describe('ShortTextField component', () => {
     const input = getByTestId('shortText') as HTMLInputElement;
 
     expect(input.value).toBe('test');
+  });
+
+  test('optionsを渡さなかった場合input type はtextが設定される', () => {
+    const { getByTestId } = render(<ShortTextField {...props} />);
+    const input = getByTestId('shortText') as HTMLInputElement;
+
+    expect(input.type).toBe('text');
+  });
+
+  test('optionsでinput type が設定できる', () => {
+    const { getByTestId } = render(<ShortTextField {...props} options={{ type: 'email' }} />);
+    const input = getByTestId('shortText') as HTMLInputElement;
+
+    expect(input.type).toBe('email');
   });
 
   test('フォームに入力した時onChangeが呼ばれる', () => {

--- a/src/__tests__/store/fieldValueState.spec.ts
+++ b/src/__tests__/store/fieldValueState.spec.ts
@@ -1,0 +1,40 @@
+import { renderRecoilHook, act } from 'react-recoil-hooks-testing-library';
+import { fieldValueSelectors, fieldValueActions } from '@/store/filedValueState';
+
+const { useFieldValueItem } = fieldValueSelectors
+const { useSetFieldValue } = fieldValueActions
+const setItemSpy = jest.spyOn(Storage.prototype, 'setItem')
+const removeItemSpy = jest.spyOn(Storage.prototype, 'removeItem')
+const getItemSpy = jest.spyOn(Storage.prototype, 'getItem')
+
+describe('store/templateState/index.ts', () => {
+
+  beforeEach(() => {
+    setItemSpy.mockClear()
+    removeItemSpy.mockClear()
+    getItemSpy.mockClear()
+  })
+
+  test('指定したキーがないとき 空のオブジェクト が返却される', () => {
+    const { result } = renderRecoilHook(() => useFieldValueItem('key'));
+    expect(result.current).toEqual({});
+  });
+
+  test('localStorage に値があるときその値が初期値となる', () => {
+    getItemSpy.mockReturnValueOnce('{"key": {"key": "value"}}')
+    const { result } = renderRecoilHook(() => useFieldValueItem('key'));
+    expect(result.current).toEqual({ key: 'value' });
+  })
+
+  test('テンプレートIDとフィールドIDにより値をセットし、同時にlocalStorageに永続化する', () => {
+    const { result: action } = renderRecoilHook(() => useSetFieldValue())
+
+    act(() => {
+      action.current('template', 'field', 'value')
+    })
+
+    const { result } = renderRecoilHook(() => useFieldValueItem('template'));
+    expect(result.current).toEqual({ field: 'value' });
+    expect(setItemSpy).toHaveBeenCalledWith('field_value', '{"template":{"field":"value"}}')
+  })
+})

--- a/src/__tests__/store/templateState.spec.ts
+++ b/src/__tests__/store/templateState.spec.ts
@@ -2,7 +2,7 @@ import { renderRecoilHook, act } from 'react-recoil-hooks-testing-library';
 import { templateActions, templateSelectors } from '../../store/templateState';
 
 const { useTemplateItem, useTemplates } = templateSelectors;
-const { useAddField, useRemoveField } = templateActions;
+const { useAddField, useRemoveField, useEditTitle } = templateActions;
 
 describe('store/templateState/index.ts', () => {
   test('初期値ではテンプレートは2件', () => {
@@ -69,6 +69,26 @@ describe('store/templateState/index.ts', () => {
 
     act(() => {
       expect(() => action.current('hoge', 'name')).toThrowError('not found template id: hoge')
+    })
+  });
+
+
+  test('テンプレートのタイトルを編集する', () => {
+    const { result: action } = renderRecoilHook(() => useEditTitle())
+
+    act(() => {
+      action.current('resume', 'edit-title')
+    })
+
+    const { result } = renderRecoilHook(() => useTemplateItem('resume'))
+    expect(result.current.title).toBe('edit-title')
+  })
+
+  test('存在しないIDでタイトルを編集しようとしたとき、例外を返す', () => {
+    const { result: action } = renderRecoilHook(() => useEditTitle())
+
+    act(() => {
+      expect(() => action.current('hoge', 'title')).toThrowError('not found template id: hoge')
     })
   });
 })

--- a/src/__tests__/store/templateState.spec.ts
+++ b/src/__tests__/store/templateState.spec.ts
@@ -2,7 +2,7 @@ import { renderRecoilHook, act } from 'react-recoil-hooks-testing-library';
 import { templateActions, templateSelectors } from '../../store/templateState';
 
 const { useTemplateItem, useTemplates } = templateSelectors;
-const { useAddField } = templateActions;
+const { useAddField, useRemoveField } = templateActions;
 
 describe('store/templateState/index.ts', () => {
   test('初期値ではテンプレートは2件', () => {
@@ -15,17 +15,60 @@ describe('store/templateState/index.ts', () => {
     expect(result.current.title).toBe('履歴書');
   });
 
-  // test('テンプレートにフィールドを追加する', () => {
-  //   const { result } = renderRecoilHook(() => useTemplateItem('resume'))
-  //   const prevLength = result.current.fields.length
-  //   const { result: action } = renderRecoilHook(() => useAddField())
-  //   const field = { label: '名前' } as any
+  test('テンプレートにフィールドを追加する', () => {
+    const { result: action } = renderRecoilHook(() => useAddField())
+    const field = { label: '名前' } as any
+    const { result: prev } = renderRecoilHook(() => useTemplateItem('resume'))
+    const prevLength = prev.current.fields.length
 
-  //   act(() => {
-  //     action.current('resume', field)
-  //   })
+    act(() => {
+      action.current('resume', field)
+    })
 
-  //   const { result: next } = renderRecoilHook(() => useTemplateItem('resume'))
-  //   expect(next.current.fields.length).toBe(prevLength + 1)
-  // })
-});
+    const { result } = renderRecoilHook(() => useTemplateItem('resume'))
+    expect(result.current.fields.length).toBe(prevLength + 1)
+  })
+
+  test('存在しないIDで追加しようとしたとき、例外を返す', () => {
+    const { result: action } = renderRecoilHook(() => useAddField())
+    const field = { label: '名前' } as any
+
+    act(() => {
+      expect(() => action.current('hoge', field)).toThrowError('not found template id: hoge')
+    })
+  });
+
+  test('テンプレートのフィールドを除外する', () => {
+    const { result: action } = renderRecoilHook(() => useRemoveField())
+    const { result: prev } = renderRecoilHook(() => useTemplateItem('resume'))
+    const prevLength = prev.current.fields.length
+
+    act(() => {
+      action.current('resume', 'name')
+    })
+
+    const { result } = renderRecoilHook(() => useTemplateItem('resume'))
+    expect(result.current.fields.length).toBe(prevLength - 1)
+  })
+
+  test('存在しないfieldIDで除外しようとしたとき、変わらない', () => {
+    const { result: action } = renderRecoilHook(() => useRemoveField())
+    const { result: prev } = renderRecoilHook(() => useTemplateItem('resume'))
+    const prevLength = prev.current.fields.length
+
+    act(() => {
+      action.current('resume', 'hoge')
+    })
+
+    const { result } = renderRecoilHook(() => useTemplateItem('resume'))
+    expect(result.current.fields.length).toBe(prevLength)
+  })
+
+  test('存在しないIDで除外しようとしたとき、例外を返す', () => {
+    const { result: action } = renderRecoilHook(() => useRemoveField())
+
+    act(() => {
+      expect(() => action.current('hoge', 'name')).toThrowError('not found template id: hoge')
+    })
+  });
+})

--- a/src/components/model/resume/Edit.tsx
+++ b/src/components/model/resume/Edit.tsx
@@ -1,0 +1,36 @@
+import { useRouter } from 'next/router';
+import Container from '@mui/material/Container';
+import Grid from '@mui/material/Grid';
+import ResumeForm from '@/components/model/resume/form/Form';
+import Title from '@/components/model/resume/Title';
+import { templateSelectors, templateActions } from '@/store/templateState';
+
+const Edit = () => {
+  const router = useRouter();
+  const id = router.query.id as string;
+
+  const { useTemplateItem } = templateSelectors;
+  const { useEditTitle } = templateActions;
+  const template = useTemplateItem(id);
+  const editTitle = useEditTitle();
+
+  if (!id) {
+    return null;
+  }
+
+  return (
+    <Container maxWidth="xl" sx={{ mt: 2 }}>
+      <Title title={template.title} onChange={(value) => editTitle(id, value)} sx={{ mb: 4 }} />
+      <Grid container spacing={2}>
+        <Grid item xs={8}>
+          <ResumeForm id={id as string} />
+        </Grid>
+        <Grid item xs={4}>
+          2
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Edit;

--- a/src/components/model/resume/Edit.tsx
+++ b/src/components/model/resume/Edit.tsx
@@ -23,10 +23,10 @@ const Edit = () => {
     <Container maxWidth="xl" sx={{ mt: 2 }}>
       <Title title={template.title} onChange={(value) => editTitle(id, value)} sx={{ mb: 4 }} />
       <Grid container spacing={2}>
-        <Grid item xs={8}>
+        <Grid item xs={12} lg={8}>
           <ResumeForm id={id as string} />
         </Grid>
-        <Grid item xs={4}>
+        <Grid item md={4} sx={{ display: { xs: 'none', lg: 'flex' } }}>
           2
         </Grid>
       </Grid>

--- a/src/components/model/resume/Edit.tsx
+++ b/src/components/model/resume/Edit.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useRouter } from 'next/router';
 import Container from '@mui/material/Container';
 import Grid from '@mui/material/Grid';

--- a/src/components/model/resume/Title.tsx
+++ b/src/components/model/resume/Title.tsx
@@ -63,7 +63,7 @@ const Title: React.VFC<Props> = ({ title, sx, onChange }) => {
         </>
       ) : (
         <>
-          <Typography variant="h5" component="h1" sx={{ mr: 2, flexGrow: 1 }}>
+          <Typography variant="h4" component="h1" sx={{ mr: 2, flexGrow: 1 }}>
             {value}
           </Typography>
           <Button variant="outlined" startIcon={<EditIcon />} onClick={handleEditClick}>

--- a/src/components/model/resume/Title.tsx
+++ b/src/components/model/resume/Title.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { SxProps } from '@mui/system';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import EditIcon from '@mui/icons-material/Edit';
+
+type Props = {
+  title: string;
+  onChange: (value: string) => void;
+  sx?: SxProps;
+};
+
+const Title: React.VFC<Props> = ({ title, sx, onChange }) => {
+  const [value, setValue] = useState(title);
+  const [showInput, setShowInput] = useState(false);
+
+  const handleEditClick = () => {
+    setShowInput(true);
+  };
+
+  const handleSaveClick = () => {
+    setShowInput(false);
+    onChange(value);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      handleSaveClick();
+    }
+  };
+
+  const handleChancelClick = () => {
+    setShowInput(false);
+    setValue(title);
+  };
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        ...sx,
+      }}
+    >
+      {showInput ? (
+        <>
+          <TextField
+            sx={{
+              mr: 2,
+              flexGrow: 1,
+            }}
+            size="small"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+          />
+          <Button variant="outlined" onClick={handleSaveClick} sx={{ mr: 2 }}>
+            保存
+          </Button>
+          <Button onClick={handleChancelClick}>キャンセル</Button>
+        </>
+      ) : (
+        <>
+          <Typography variant="h5" component="h1" sx={{ mr: 2, flexGrow: 1 }}>
+            {value}
+          </Typography>
+          <Button variant="outlined" startIcon={<EditIcon />} onClick={handleEditClick}>
+            編集
+          </Button>
+        </>
+      )}
+    </Box>
+  );
+};
+
+export default Title;

--- a/src/components/model/resume/form/Form.tsx
+++ b/src/components/model/resume/form/Form.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import ShortTextField from './ShortTextField';
+import Title from '@/components/model/resume/Title';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import Grid from '@mui/material/Grid';
 import CardContent from '@mui/material/CardContent';
-import Typography from '@mui/material/Typography';
-import { templateSelectors } from '../../../../store/templateState';
-import { Block, Field } from '../../../../store/templateState/types';
-
-const { useTemplateItem } = templateSelectors;
+import { templateSelectors } from '@/store/templateState';
+import { fieldValueSelectors, fieldValueActions } from '@/store/filedValueState';
+import { Block, Field } from '@/store/templateState/types';
 
 type Props = {
   id: string;
@@ -43,21 +42,28 @@ function componentMapping(type: Field['type'], props: FieldProps<any>) {
 }
 
 const ResumeForm: React.FC<Props> = ({ id }) => {
+  const { useTemplateItem } = templateSelectors;
+  const { useFieldValueItem } = fieldValueSelectors;
+  const { useSetFieldValue } = fieldValueActions;
+  const fieldValue = useFieldValueItem(id);
+  const setFieldValue = useSetFieldValue();
   const template = useTemplateItem(id);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+  };
 
   return (
     <Card sx={{ p: 2 }}>
       <CardContent>
-        <Typography variant="h4" component="h1">
-          {template.title}を作成
-        </Typography>
-        <Box component="form" noValidate autoComplete="off">
+        <Title title={template.title} onChange={() => {}} />
+        <Box component="form" noValidate autoComplete="off" onSubmit={handleSubmit}>
           {template.fields.map((field) => (
             <Grid key={field.order} xs={gridCols[field.block]} sx={{ my: 2 }}>
               {componentMapping(field.type, {
                 label: field.label,
-                value: '',
-                onChange: () => {},
+                value: fieldValue[field.fieldId],
+                onChange: (value) => setFieldValue(id, field.fieldId, value),
               })}
             </Grid>
           ))}

--- a/src/components/model/resume/form/Form.tsx
+++ b/src/components/model/resume/form/Form.tsx
@@ -5,7 +5,7 @@ import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import Grid from '@mui/material/Grid';
 import CardContent from '@mui/material/CardContent';
-import { templateSelectors } from '@/store/templateState';
+import { templateSelectors, templateActions } from '@/store/templateState';
 import { fieldValueSelectors, fieldValueActions } from '@/store/filedValueState';
 import { Block, Field } from '@/store/templateState/types';
 
@@ -43,11 +43,13 @@ function componentMapping(type: Field['type'], props: FieldProps<any>) {
 
 const ResumeForm: React.FC<Props> = ({ id }) => {
   const { useTemplateItem } = templateSelectors;
+  const { useEditTitle } = templateActions;
   const { useFieldValueItem } = fieldValueSelectors;
   const { useSetFieldValue } = fieldValueActions;
   const fieldValue = useFieldValueItem(id);
   const setFieldValue = useSetFieldValue();
   const template = useTemplateItem(id);
+  const editTitle = useEditTitle();
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -56,7 +58,7 @@ const ResumeForm: React.FC<Props> = ({ id }) => {
   return (
     <Card sx={{ p: 2 }}>
       <CardContent>
-        <Title title={template.title} onChange={() => {}} />
+        <Title title={template.title} onChange={(value) => edititle(id, value)} />
         <Box component="form" noValidate autoComplete="off" onSubmit={handleSubmit}>
           {template.fields.map((field) => (
             <Grid key={field.order} xs={gridCols[field.block]} sx={{ my: 2 }}>

--- a/src/components/model/resume/form/Form.tsx
+++ b/src/components/model/resume/form/Form.tsx
@@ -1,13 +1,19 @@
 import React from 'react';
 import ShortTextField from './ShortTextField';
-import Title from '@/components/model/resume/Title';
+import ShortTextWithRubyField from './ShortTextWithRubyField';
+import LongTextField from './LongTextField';
+import ImageField from './ImageField';
+import NumberField from './NumberField';
+import DateField from './DateField';
+import ListField from './ListField';
+import TableField from './TableField';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import Grid from '@mui/material/Grid';
 import CardContent from '@mui/material/CardContent';
 import { templateSelectors, templateActions } from '@/store/templateState';
 import { fieldValueSelectors, fieldValueActions } from '@/store/filedValueState';
-import { Block, Field } from '@/store/templateState/types';
+import { Field } from '@/store/templateState/types';
 
 type Props = {
   id: string;
@@ -21,35 +27,52 @@ export type FieldProps<T, U = {}> = {
 };
 
 /**
- * ブロックのサイズに対応するgridのサイズ
- */
-const gridCols: Record<Block, number> = {
-  1: 4,
-  2: 6,
-  3: 12,
-} as const;
-
-/**
  * フィールドのタイプに対応するコンポーネント
  */
-function componentMapping(type: Field['type'], props: FieldProps<any>) {
-  switch (type) {
+function componentMapping(field: Field, value: any, onChange: (value: any) => void) {
+  switch (field.type) {
     case 'shortText':
-      return <ShortTextField {...props} />;
-    default:
-      return null;
+      return (
+        <ShortTextField
+          label={field.label}
+          options={field.options}
+          value={value}
+          onChange={onChange}
+        />
+      );
+    case 'shortTextWithRuby':
+      return <ShortTextWithRubyField label={field.label} value={value} onChange={onChange} />;
+    case 'longText':
+      return <LongTextField label={field.label} value={value} onChange={onChange} />;
+    case 'image':
+      return <ImageField label={field.label} value={value} onChange={onChange} />;
+    case 'number':
+      return (
+        <NumberField
+          label={field.label}
+          options={field.options}
+          value={value}
+          onChange={onChange}
+        />
+      );
+    case 'date':
+      return <DateField label={field.label} value={value} onChange={onChange} />;
+    case 'list':
+      return <ListField label={field.label} value={value} onChange={onChange} />;
+    case 'table':
+      return (
+        <TableField label={field.label} options={field.options} value={value} onChange={onChange} />
+      );
   }
 }
 
 const ResumeForm: React.FC<Props> = ({ id }) => {
   const { useTemplateItem } = templateSelectors;
-  const { useEditTitle } = templateActions;
   const { useFieldValueItem } = fieldValueSelectors;
   const { useSetFieldValue } = fieldValueActions;
   const fieldValue = useFieldValueItem(id);
   const setFieldValue = useSetFieldValue();
   const template = useTemplateItem(id);
-  const editTitle = useEditTitle();
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -58,17 +81,23 @@ const ResumeForm: React.FC<Props> = ({ id }) => {
   return (
     <Card sx={{ p: 2 }}>
       <CardContent>
-        <Title title={template.title} onChange={(value) => edititle(id, value)} />
         <Box component="form" noValidate autoComplete="off" onSubmit={handleSubmit}>
-          {template.fields.map((field) => (
-            <Grid key={field.order} xs={gridCols[field.block]} sx={{ my: 2 }}>
-              {componentMapping(field.type, {
-                label: field.label,
-                value: fieldValue[field.fieldId],
-                onChange: (value) => setFieldValue(id, field.fieldId, value),
-              })}
-            </Grid>
-          ))}
+          <Grid container spacing={2} alignItems="flex-end">
+            {template.fields.map((field) => (
+              <Grid
+                item
+                key={field.fieldId}
+                xs={12}
+                md={field.block}
+                sx={{ my: 2 }}
+                data-testid="field"
+              >
+                {componentMapping(field, fieldValue[field.fieldId], (value) =>
+                  setFieldValue(id, field.fieldId, value),
+                )}
+              </Grid>
+            ))}
+          </Grid>
         </Box>
       </CardContent>
     </Card>

--- a/src/components/model/resume/form/NumberField.tsx
+++ b/src/components/model/resume/form/NumberField.tsx
@@ -1,8 +1,15 @@
 import React from 'react';
 import { FieldProps } from './Form';
 import TextField from '@mui/material/TextField';
+import InputAdornment from '@mui/material/InputAdornment';
+import { NumberFieldOptions } from '@/store/templateState/types';
 
-const NumberField: React.FC<FieldProps<number>> = ({ label, value, onChange }) => {
+const NumberField: React.FC<FieldProps<number, NumberFieldOptions>> = ({
+  label,
+  value,
+  onChange,
+  options,
+}) => {
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     onChange(Number(event.target.value));
   };
@@ -11,11 +18,16 @@ const NumberField: React.FC<FieldProps<number>> = ({ label, value, onChange }) =
     <TextField
       type="number"
       label={label}
+      InputProps={{
+        endAdornment: <InputAdornment position="end">{options?.unit}</InputAdornment>,
+      }}
+      inputProps={{
+        'data-testid': 'input',
+      }}
       value={value}
       onChange={handleChange}
       variant="outlined"
       fullWidth
-      inputProps={{ 'data-testid': 'input' }}
     />
   );
 };

--- a/src/components/model/resume/form/ShortTextField.tsx
+++ b/src/components/model/resume/form/ShortTextField.tsx
@@ -1,14 +1,21 @@
 import React from 'react';
 import { FieldProps } from './Form';
 import TextField from '@mui/material/TextField';
+import { ShortTextFieldOptions } from '@/store/templateState/types';
 
-const ShortTextField: React.FC<FieldProps<string>> = ({ label, value, onChange }) => {
+const ShortTextField: React.FC<FieldProps<string, ShortTextFieldOptions>> = ({
+  label,
+  value,
+  onChange,
+  options = { type: 'text' },
+}) => {
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     onChange(event.target.value);
   };
 
   return (
     <TextField
+      type={options.type}
       label={label}
       value={value}
       onChange={handleChange}

--- a/src/components/model/resume/form/TableField.tsx
+++ b/src/components/model/resume/form/TableField.tsx
@@ -5,6 +5,7 @@ import type { FieldProps } from './Form';
 import type { TableFieldValue, TableFieldOptions } from '@/store/templateState/types';
 import Button from '@mui/material/Button';
 import AddIcon from '@mui/icons-material/Add';
+import dayjs from 'dayjs';
 
 const TableField: React.FC<FieldProps<TableFieldValue, TableFieldOptions>> = ({
   label,
@@ -18,8 +19,11 @@ const TableField: React.FC<FieldProps<TableFieldValue, TableFieldOptions>> = ({
   const handleCellEditCommit = useCallback(
     (params: GridCellEditCommitParams) => {
       const newValue = value.map((row) => {
+        console.log(params.value instanceof Date);
+        const value =
+          params.value instanceof Date ? dayjs(params.value).format('YYYY/MM/DD') : params.value;
         if (row.id === params.id) {
-          return { ...row, [params.field]: params.value };
+          return { ...row, [params.field]: value };
         } else {
           return row;
         }

--- a/src/pages/resume/[id]/create.tsx
+++ b/src/pages/resume/[id]/create.tsx
@@ -1,27 +1,12 @@
-import { useRouter } from 'next/router';
-import Container from '@mui/material/Container';
-import Grid from '@mui/material/Grid';
-import ResumeForm from '../../../components/model/resume/form/Form';
+import { NextPage } from 'next';
+import dynamic from 'next/dynamic';
 
-const Create = () => {
-  const router = useRouter();
-  const { id } = router.query;
-  if (!id) {
-    return null;
-  }
+const DynamicComponentWithNoSSR = dynamic(() => import('@/components/model/resume/Edit'), {
+  ssr: false,
+});
 
-  return (
-    <Container maxWidth="xl" sx={{ mt: 2 }}>
-      <Grid container spacing={2}>
-        <Grid item xs={8}>
-          <ResumeForm id={id as string} />
-        </Grid>
-        <Grid item xs={4}>
-          2
-        </Grid>
-      </Grid>
-    </Container>
-  );
+const Create: NextPage = () => {
+  return <DynamicComponentWithNoSSR />;
 };
 
 export default Create;

--- a/src/pages/resume/[id]/create.tsx
+++ b/src/pages/resume/[id]/create.tsx
@@ -2,7 +2,6 @@ import { useRouter } from 'next/router';
 import Container from '@mui/material/Container';
 import Grid from '@mui/material/Grid';
 import ResumeForm from '../../../components/model/resume/form/Form';
-import { Template } from '../../../store/templateState/types';
 
 const Create = () => {
   const router = useRouter();

--- a/src/store/RecoilKeys.ts
+++ b/src/store/RecoilKeys.ts
@@ -5,10 +5,12 @@
 
 export enum RecoilAtomKeys {
   TEMPLATE_STATE = 'templateState',
-  SELECTED_ID_TEMPLATE = 'selectedIdTemplate'
+  SELECTED_ID_TEMPLATE = 'selectedIdTemplate',
+  FIELD_VALUE_STATE = 'fieldValueState'
 }
 
 export enum RecoilSelectorKeys {
   TEMPLATE_LIST = 'templateList',
-  SELECTED_TEMPLATE_ITEM = 'selectedTemplateItem'
+  SELECTED_TEMPLATE_ITEM = 'selectedTemplateItem',
+  FIELD_VALUE_ITEM = 'fieldValueItem'
 }

--- a/src/store/effects/localStorageEffect.ts
+++ b/src/store/effects/localStorageEffect.ts
@@ -1,0 +1,16 @@
+import { AtomEffect } from 'recoil'
+
+const localStorageEffect = <T>(key: string): AtomEffect<T> => ({ setSelf, onSet }) => {
+  const savedValue = localStorage.getItem(key)
+  if (savedValue != null) {
+    setSelf(JSON.parse(savedValue));
+  }
+
+  onSet((newValue, _, isReset) => {
+    isReset
+      ? localStorage.removeItem(key)
+      : localStorage.setItem(key, JSON.stringify(newValue));
+  });
+};
+
+export default localStorageEffect

--- a/src/store/filedValueState/index.ts
+++ b/src/store/filedValueState/index.ts
@@ -1,0 +1,41 @@
+import { atom, selectorFamily, useSetRecoilState, useRecoilValue } from 'recoil'
+import { RecoilAtomKeys, RecoilSelectorKeys } from '../RecoilKeys'
+import { cloneDeep } from 'lodash-es'
+import type { FieldValueState, FieldValueSelectors, FieldValueActions } from './types'
+import localStorageEffect from '@/store/effects/localStorageEffect'
+
+
+const fieldValueState = atom<FieldValueState>({
+  key: RecoilAtomKeys.FIELD_VALUE_STATE,
+  default: {},
+  effects_UNSTABLE: [localStorageEffect('field_value')]
+})
+
+/**
+ * テンプレートIDとフィールドのIDを指定して、フィールドの値を取得する
+ */
+const fieldValueSelector = selectorFamily<Record<string, unknown>, string>({
+  key: RecoilSelectorKeys.FIELD_VALUE_ITEM,
+  get: (templateId) => ({ get }) => {
+    const fieldValue = get(fieldValueState)
+    return fieldValue[templateId] ?? {}
+  }
+})
+
+export const fieldValueSelectors: FieldValueSelectors = {
+  useFieldValueItem: (templateId) => useRecoilValue(fieldValueSelector(templateId))
+}
+
+export const fieldValueActions: FieldValueActions = {
+  useSetFieldValue: () => {
+
+    const setState = useSetRecoilState(fieldValueState)
+    return (templateId: string, fieldId: string, value: unknown) => {
+      setState(prev => {
+        const copy = cloneDeep(prev)
+        copy[templateId] = { ...copy[templateId], [fieldId]: value }
+        return copy
+      })
+    }
+  },
+}

--- a/src/store/filedValueState/types.ts
+++ b/src/store/filedValueState/types.ts
@@ -1,0 +1,9 @@
+export type FieldValueState = Record<string, Record<string, unknown>>
+
+export type FieldValueActions = {
+  useSetFieldValue: () => (templateId: string, fieldId: string, value: unknown) => void;
+}
+
+export type FieldValueSelectors = {
+  useFieldValueItem: (templateId: string) => Record<string, unknown>;
+}

--- a/src/store/templateState/index.ts
+++ b/src/store/templateState/index.ts
@@ -2,34 +2,37 @@ import { atom, selector, selectorFamily, useSetRecoilState, useRecoilValue } fro
 import { RecoilAtomKeys, RecoilSelectorKeys } from '../RecoilKeys'
 import { cloneDeep } from 'lodash-es'
 import type { Template, TemplateState, TemplateSelectors, TemplateActions, Field } from './types'
-import { removeItemAtIndex, replaceItemAtIndex } from '../../lib/utils'
+import { replaceItemAtIndex } from '../../lib/utils'
+import localStorageEffect from '@/store/effects/localStorageEffect'
 
-const initialTemplates = (): TemplateState => ({
-  templates: [
-    {
-      id: 'resume',
-      title: '履歴書',
-      fields: [
-        {
-          label: '名前',
-          order: 1,
-          position: 'left',
-          block: 3,
-          type: 'shortText',
-          options: {}
-        }
-      ]
-    },
-    {
-      id: 'curriculumVitae',
-      title: '職務経歴書',
-      fields: []
-    }]
-})
+const initialTemplates = (): TemplateState => [
+  {
+    id: 'resume',
+    title: '履歴書',
+    fields: [
+      {
+        fieldId: 'name',
+        label: '名前',
+        order: 1,
+        position: 'left',
+        block: 3,
+        type: 'shortText',
+        options: {}
+      }
+    ]
+  },
+  {
+    id: 'curriculumVitae',
+    title: '職務経歴書',
+    fields: []
+  }
+]
+
 
 const templateState = atom<TemplateState>({
   key: RecoilAtomKeys.TEMPLATE_STATE,
-  default: initialTemplates()
+  default: initialTemplates(),
+  effects_UNSTABLE: [localStorageEffect('template')]
 })
 
 export const templateActions: TemplateActions = {
@@ -38,37 +41,32 @@ export const templateActions: TemplateActions = {
     const setState = useSetRecoilState(templateState)
     return (id: string, field: Field) => {
       setState(prev => {
-        const index = prev.templates.findIndex(v => v.id === id)
+        const index = prev.findIndex(v => v.id === id)
         if (index === -1) {
-          throw new Error('not found template id:' + id)
+          throw new Error('not found template id: ' + id)
         }
 
-        const copy = cloneDeep(prev.templates[index])
+        const copy = cloneDeep(prev[index])
         copy.fields = [...copy.fields, field]
 
-        return {
-          ...prev,
-          templates: replaceItemAtIndex(prev.templates, index, copy)
-        }
+        return replaceItemAtIndex(prev, index, copy)
       })
     }
   },
   useRemoveField: () => {
     const setState = useSetRecoilState(templateState)
-    return (id: string, index: number) => {
+    return (id: string, fieldId: string) => {
       setState(prev => {
-        const template = prev.templates.find(v => v.id === id)
-        if (!template) {
-          throw new Error('not found template id:' + id)
+        const index = prev.findIndex(v => v.id === id)
+        if (index === -1) {
+          throw new Error('not found template id: ' + id)
         }
 
-        const copy = cloneDeep(template)
-        copy.fields = removeItemAtIndex(copy.fields, index)
+        const copy = cloneDeep(prev[index])
+        copy.fields = copy.fields.filter(v => v.fieldId !== fieldId)
 
-        return {
-          ...prev,
-          templates: replaceItemAtIndex(prev.templates, index, copy)
-        }
+        return replaceItemAtIndex(prev, index, copy)
+
       })
     }
   }
@@ -80,7 +78,7 @@ export const templateActions: TemplateActions = {
 const templateListSelector = selector<Template[]>({
   key: RecoilSelectorKeys.TEMPLATE_LIST,
   get: ({ get }) => {
-    const templates = get(templateState).templates
+    const templates = get(templateState)
     return templates
   }
 })
@@ -88,10 +86,10 @@ const templateListSelector = selector<Template[]>({
 /**
  * 選択中のテンプレートを取得する
  */
-export const selectedTemplateItemSelector = selectorFamily<Template, string>({
+const selectedTemplateItemSelector = selectorFamily<Template, string>({
   key: RecoilSelectorKeys.SELECTED_TEMPLATE_ITEM,
   get: (id: string) => ({ get }) => {
-    const templates = get(templateListSelector)
+    const templates = get(templateState)
     const selectedTemplate = templates.find(template => template.id === id)
 
     if (!selectedTemplate) {

--- a/src/store/templateState/index.ts
+++ b/src/store/templateState/index.ts
@@ -81,7 +81,7 @@ const initialTemplates = (): TemplateState => [
               headerName: '年月',
               editable: true,
               type: 'date',
-              width: 200,
+              width: 150,
             },
             {
               field: 'personalHistory',
@@ -105,7 +105,7 @@ const initialTemplates = (): TemplateState => [
               headerName: '年月',
               editable: true,
               type: 'date',
-              width: 200,
+              width: 150,
             },
             {
               field: 'certification',

--- a/src/store/templateState/index.ts
+++ b/src/store/templateState/index.ts
@@ -14,11 +14,153 @@ const initialTemplates = (): TemplateState => [
         fieldId: 'name',
         label: '名前',
         order: 1,
-        position: 'left',
-        block: 3,
+        block: 10,
+        type: 'shortTextWithRuby',
+      },
+      {
+        fieldId: 'photo',
+        label: '写真',
+        order: 2,
+        block: 2,
+        type: 'image'
+      },
+      {
+        fieldId: 'birthday',
+        label: '生年月日',
+        order: 3,
+        block: 10,
+        type: 'date'
+      },
+      {
+        fieldId: 'age',
+        label: '年齢',
+        order: 4,
+        block: 2,
+        type: 'number',
+        options: {
+          unit: '歳'
+        }
+      },
+      {
+        fieldId: 'address',
+        label: '住所',
+        order: 5,
+        block: 12,
+        type: 'shortTextWithRuby'
+      },
+      {
+        fieldId: 'tel',
+        label: '電話番号',
+        order: 6,
+        block: 6,
         type: 'shortText',
-        options: {}
-      }
+        options: {
+          type: 'tel'
+        }
+      },
+      {
+        fieldId: 'email',
+        label: 'email',
+        order: 7,
+        block: 6,
+        type: 'shortText',
+        options: {
+          type: 'email'
+        }
+      },
+      {
+        fieldId: 'career',
+        label: '学歴・職歴',
+        order: 8,
+        block: 12,
+        type: 'table',
+        options: {
+          columns: [
+            {
+              field: 'yearMonth',
+              headerName: '年月',
+              editable: true,
+              type: 'date',
+              width: 200,
+            },
+            {
+              field: 'personalHistory',
+              headerName: '学歴・職歴',
+              editable: true,
+              width: 700,
+            },
+          ],
+        },
+      },
+      {
+        fieldId: 'certification',
+        label: '資格・免許',
+        order: 9,
+        block: 12,
+        type: 'table',
+        options: {
+          columns: [
+            {
+              field: 'yearMonth',
+              headerName: '年月',
+              editable: true,
+              type: 'date',
+              width: 200,
+            },
+            {
+              field: 'certification',
+              headerName: '資格・免許',
+              editable: true,
+              width: 700,
+            },
+          ],
+        },
+      },
+      {
+        fieldId: 'reasonsForApplication',
+        label: '志望動機,自己PR,趣味,特技など',
+        order: 10,
+        block: 12,
+        type: 'longText'
+      },
+      {
+        fieldId: 'commute',
+        label: '通勤時間',
+        order: 11,
+        block: 3,
+        type: 'shortText'
+      },
+      {
+        fieldId: 'dependents',
+        label: '扶養家族（配偶者を除く）',
+        order: 12,
+        block: 3,
+        type: 'number',
+        options: {
+          unit: '人'
+        }
+      },
+      {
+        fieldId: 'spouse',
+        label: '配偶者',
+        order: 13,
+        block: 3,
+        type: 'number'
+      },
+      {
+        fieldId: 'obligationToSupportSpouse',
+        label: '配偶者の扶養義務',
+        order: 14,
+        block: 3,
+        type: 'number'
+      },
+      {
+        fieldId: 'other',
+        label: '本人希望記入欄（特に待遇・職種・勤務時間・その他についての希望などがあれば記入）',
+        order: 15,
+        block: 12,
+        type: 'longText'
+      },
     ]
   },
   {

--- a/src/store/templateState/index.ts
+++ b/src/store/templateState/index.ts
@@ -69,6 +69,22 @@ export const templateActions: TemplateActions = {
 
       })
     }
+  },
+  useEditTitle: () => {
+    const setState = useSetRecoilState(templateState)
+    return (id: string, title: string) => {
+      setState(prev => {
+        const index = prev.findIndex(v => v.id === id)
+        if (index === -1) {
+          throw new Error('not found template id: ' + id)
+        }
+
+        const copy = cloneDeep(prev[index])
+        copy.title = title
+
+        return replaceItemAtIndex(prev, index, copy)
+      })
+    }
   }
 }
 

--- a/src/store/templateState/types.ts
+++ b/src/store/templateState/types.ts
@@ -49,6 +49,7 @@ export type TemplateState = Template[];
 export type TemplateActions = {
   useAddField: () => (id: string, field: Field) => void;
   useRemoveField: () => (id: string, fieldId: string) => void;
+  useEditTitle: () => (id: string, title: string) => void;
 }
 
 export type TemplateSelectors = {

--- a/src/store/templateState/types.ts
+++ b/src/store/templateState/types.ts
@@ -11,6 +11,7 @@ export type Block = 1 | 2 | 3
 export type Position = 'left' | 'center' | 'rigth'
 
 type BaseField<T extends string, U extends Record<string, unknown> = {}> = {
+  fieldId: string;
   label: string;
   order: number;
   position: Position;
@@ -43,13 +44,11 @@ export type TableFieldOptions = { columns: GridColumns }
 
 export type Field = ShortTextField | ShortTextWithRubyField | LongTextField | NumberField | DateField | ListField | TimeLineField | TableField
 
-export type TemplateState = {
-  templates: Template[];
-}
+export type TemplateState = Template[];
 
 export type TemplateActions = {
   useAddField: () => (id: string, field: Field) => void;
-  useRemoveField: () => (id: string, index: number) => void;
+  useRemoveField: () => (id: string, fieldId: string) => void;
 }
 
 export type TemplateSelectors = {

--- a/src/store/templateState/types.ts
+++ b/src/store/templateState/types.ts
@@ -6,21 +6,20 @@ export type Template = {
   fields: Field[];
 }
 
-export type Block = 1 | 2 | 3
+export type Block = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12
 
-export type Position = 'left' | 'center' | 'rigth'
-
-type BaseField<T extends string, U extends Record<string, unknown> = {}> = {
+type BaseField<T extends string, U extends Record<string, unknown> | undefined = undefined> = {
   fieldId: string;
   label: string;
   order: number;
-  position: Position;
   block: Block;
   type: T;
-  options: U;
+  options?: U;
 }
 
-type ShortTextField = BaseField<'shortText'>
+export type ShortTextFieldOptions = { 'type': 'text' | 'number' | 'email' | 'tel' | 'password' | 'url' }
+
+type ShortTextField = BaseField<'shortText', ShortTextFieldOptions>
 
 type ShortTextWithRubyField = BaseField<'shortTextWithRuby'>
 
@@ -28,21 +27,24 @@ export type ShortTextWithRubyValue = { ruby: string, value: string }
 
 type LongTextField = BaseField<'longText'>
 
-type NumberField = BaseField<'number'>
+type ImageField = BaseField<'image'>
+
+export type NumberFieldOptions = { unit: string }
+
+type NumberField = BaseField<'number', NumberFieldOptions>
 
 type DateField = BaseField<'date'>
 
 type ListField = BaseField<'list'>
 
-type TimeLineField = BaseField<'timeLine'>
+export type TableFieldOptions = { columns: GridColumns }
 
-type TableField = BaseField<'table'>
+type TableField = BaseField<'table', TableFieldOptions>
 
 export type TableFieldValue = GridRowsProp
 
-export type TableFieldOptions = { columns: GridColumns }
 
-export type Field = ShortTextField | ShortTextWithRubyField | LongTextField | NumberField | DateField | ListField | TimeLineField | TableField
+export type Field = ShortTextField | ShortTextWithRubyField | LongTextField | ImageField | NumberField | DateField | ListField | TableField
 
 export type TemplateState = Template[];
 

--- a/src/stories/model/resume/Title.stories.tsx
+++ b/src/stories/model/resume/Title.stories.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import Title from '@/components/model/resume/Title';
+import WithStorybook from '@/stories/utils/WithStorybook';
+
+export default {
+  title: 'model/resume/Title',
+  component: Title,
+} as ComponentMeta<typeof Title>;
+
+const Template: ComponentStory<typeof Title> = (args) => <Title {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  title: '履歴書',
+  onChange: (value: string) => console.log(value),
+};

--- a/src/stories/model/resume/form/NumberField.stories.tsx
+++ b/src/stories/model/resume/form/NumberField.stories.tsx
@@ -14,4 +14,7 @@ Default.args = {
   label: '年齢',
   value: 25,
   onChange: (value: number) => console.log(value),
+  options: {
+    unit: '歳',
+  },
 };


### PR DESCRIPTION
## 関連する Issue

* #3

## やったこと

*  テンプレートの持つフィールドの一覧を表示する
* テンプレートのタイトルを編集できるように
* Recoil の state に fieldValueを追加。localStorageに保存する
* `shortTextField` が `input type` を指定できるように
* `number` が単位を設定できるように

## やらないこと

* 

## スクリーンショット

![スクリーンショット 2021-12-31 18 17 57](https://user-images.githubusercontent.com/59350345/147815589-8b7a863a-ce59-456d-ac85-3a7306c60119.png)
![スクリーンショット 2021-12-31 18 36 31](https://user-images.githubusercontent.com/59350345/147815636-c722b66f-d2cf-468c-93ed-95d0c670a19d.png)


## 動作確認

* 

## その他

* 